### PR TITLE
Datepicker improvement

### DIFF
--- a/src/components/formik/datepicker/index.js
+++ b/src/components/formik/datepicker/index.js
@@ -15,6 +15,34 @@ const FormikDatepicker = ({
 }) => {
   const value = values[name] ? moment.utc(values[name]) : moment.utc();
 
+  // date pickers constraints
+  let minDate;
+  let initialDate;
+  let pickerDisabled = false;
+  // if picker is dateFrom
+  if (name === "dateFrom") {
+    minDate = moment()
+      .utc()
+      .toDate();
+    initialDate = value.toDate();
+    // if picker is dateFrom
+  } else if (name === "dateTo") {
+    // if picker 'dateFrom' selectet i set min date and default value for 'dateTo'
+    if (values["dateFrom"] !== "") {
+      minDate = moment
+        .utc(values["dateFrom"])
+        .add(1, "days")
+        .toDate();
+      initialDate = moment
+        .utc(values["dateFrom"])
+        .add(1, "days")
+        .toDate();
+      // if picker 'dateFrom' not selected -> 'dateTo' disabled
+    } else {
+      pickerDisabled = true;
+    }
+  }
+
   return (
     <DatePicker
       textField={{
@@ -22,8 +50,11 @@ const FormikDatepicker = ({
       }}
       name={name}
       label={label}
+      minDate={minDate}
+      //initialPickerDate={initialDate}
+      disabled={pickerDisabled}
       placeholder="Seleziona una data..."
-      value={value.toDate()}
+      value={initialDate}
       formatDate={date => moment(date).format("DD/MM/YYYY")}
       onSelectDate={date => {
         handleChange({


### PR DESCRIPTION
Selection dates improvements
set the minimum date to the actual date for the datePicker 'dateFrom' and disable the datePicker 'dateTo'.
When the user select the date 'dateFrom', the datePicker 'dateTo' becomes available, and the minimum date
is set to the 'dateFrom' minimum date plus one day. The date 'dateTo' scrolls up to the first available date.